### PR TITLE
Upgrade athena driver to suport metabase v0.35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM metabase/metabase:v0.35.2
 
-ADD https://github.com/dacort/metabase-athena-driver/releases/download/v0.1.0/athena.metabase-driver.jar plugins/
+ADD https://github.com/dacort/metabase-athena-driver/releases/download/v1.0.0/athena.metabase-driver.jar plugins/
 
 ENV MGID=${MGID:-2000}
 


### PR DESCRIPTION
Fix error `No suitable driver found for jdbc:awsathena://athena.us-west-2.amazonaws.com:443` when use metabase v0.35.2

See details [here](https://github.com/dacort/metabase-athena-driver/issues/35)